### PR TITLE
fix: ensure that port and counter is seperated by a space

### DIFF
--- a/roles/nftables/templates/functions.j2
+++ b/roles/nftables/templates/functions.j2
@@ -166,7 +166,7 @@ add rule ip filter {{ chain }} {# #}
 {%- if dst_set %} ip daddr @{{ dst_set }} {% endif -%}
 {{ proto }} dport {# #}
 {%- if dst_ports | length > 1 %} { {{ dst_ports | join(', ') }} }{% else %} {{ dst_ports[0] }}{% endif %}
-counter {{ rule.action | default('accept') }} comment "{{ rule.name | default('unspecified', true) }}"
+{# #} counter {{ rule.action | default('accept') }} comment "{{ rule.name | default('unspecified', true) }}"
     {% endfor %}
 {% else %}
 add rule ip filter {{ chain }} {# #}
@@ -174,7 +174,7 @@ add rule ip filter {{ chain }} {# #}
 {%- if dst_zone %} oifname @{{ dst_zone }}_ifaces {% endif -%}
 {%- if src_set %} ip saddr @{{ src_set }} {% endif -%}
 {%- if dst_set %} ip daddr @{{ dst_set }} {% endif -%}
-counter {{ rule.action | default('accept') }} comment "{{ rule.name | default('unspecified', true) }}"
+{# #} counter {{ rule.action | default('accept') }} comment "{{ rule.name | default('unspecified', true) }}"
 {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
An issue was seen where the port and counter config in the generated nftables.conf wasn't seperated by a space:
![image](https://github.com/user-attachments/assets/a65b06d9-3f12-45e7-8994-a0f0c600c0bd)

This pr fixes this:
![image](https://github.com/user-attachments/assets/fe38d60e-5e65-4881-9aad-51f497db387f)
