### PR TITLE
Feat: Update nftables_url_script.sh

### DIFF
--- a/roles/nftables/molecule/default/group_vars/all/sets.yml
+++ b/roles/nftables/molecule/default/group_vars/all/sets.yml
@@ -25,3 +25,6 @@ nftables_dnsmasq_sets_1:
   - name: other-external-hosts
     hosts:
       - bing.com
+
+nftables_url_sets_refresh_services:
+  - crond # an example to ensure molecule tests go through

--- a/roles/nftables/tasks/nftables_sets_urls.yml
+++ b/roles/nftables/tasks/nftables_sets_urls.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Install jq
+- name: Install dependencies
   ansible.builtin.package:
-    name: jq
+    name: "{{ nftables_url_dependencies }}"
     state: present
 
 - name: Ensure nftables.d directory exists
@@ -24,8 +24,8 @@
   loop: "{{ nftables_sets | selectattr('urls', 'defined') | list }}"
 
 - name: Ensure url script exists
-  ansible.builtin.copy:
-    src: nftables_url_script.sh
+  ansible.builtin.template:
+    src: nftables_url_script.sh.j2
     dest: "/usr/local/bin/nftables_url_script.sh"
     owner: root
     group: root
@@ -39,6 +39,13 @@
     group: root
     mode: "0644"
   notify: Refresh nftables urls
+
+- name: Daily refresh of nftables_urls
+  ansible.builtin.cron:
+    name: "refresh nftables_urls"
+    minute: "30"
+    hour: "3"
+    job: "/usr/local/bin/nftables_url_script.sh"
 
 - name: Refresh nftables urls if needed
   ansible.builtin.meta: flush_handlers

--- a/roles/nftables/templates/nftables_url_script.sh.j2
+++ b/roles/nftables/templates/nftables_url_script.sh.j2
@@ -61,7 +61,7 @@ if ! jq -c '.[]' "$config_path" > /dev/null; then
     exit 1
 fi
 
-jq -c '.[]' "$config_path" | while read -r line; do
+while read -r line; do
     log "Processing: $line"
 
     name=$(jq -r '.name' <<<"$line")
@@ -113,9 +113,19 @@ jq -c '.[]' "$config_path" | while read -r line; do
         log "Skipping generating nftables file \"$nftables_dir_path/$name.conf\""
     fi
 
-done
+done <<< "$(jq -c '.[]' "$config_path")"
 
 if [[ "$reload_nftables" == "true" && "$1" != "no_reload" ]]; then
     log "Reloading nftables"
     systemctl restart nftables
+
+{% for nftables_url_sets_refresh_service in nftables_url_sets_refresh_services | default([]) %}
+    log "Sleeping for 5 seconds"
+    sleep 5
+    log "Reloading {{ nftables_url_sets_refresh_service }}"
+    systemctl restart {{ nftables_url_sets_refresh_service }}
+{% endfor %}
 fi
+
+log "Done refreshing lists"
+

--- a/roles/nftables/vars/Debian.yml
+++ b/roles/nftables/vars/Debian.yml
@@ -1,2 +1,5 @@
 ---
 nftables_config_path: "/etc/nftables.conf"
+nftables_url_dependencies:
+  - jq
+  - cron

--- a/roles/nftables/vars/RedHat.yml
+++ b/roles/nftables/vars/RedHat.yml
@@ -3,3 +3,6 @@ nftables_conflicting_services:
   - iptables
   - firewalld
 nftables_config_path: "/etc/sysconfig/nftables.conf"
+nftables_url_dependencies:
+  - jq
+  - cronie


### PR DESCRIPTION
Allows for restart of systemd services post nftables restart

small change: if nftables_url_script is used, it'll automatically refresh daily